### PR TITLE
Fix nil tagline

### DIFF
--- a/server.go
+++ b/server.go
@@ -103,7 +103,10 @@ func searchHandlerFunc(driver neo4j.Driver, database string) func(http.ResponseW
 				record := records.Record()
 				released, _ := record.Get("released")
 				title, _ := record.Get("title")
-				tagline, _ := record.Get("tagline")
+				tagline, ok := record.Get("tagline")
+				if !ok || tagline == nil {
+					tagline = ""
+				}
 				votes, ok := record.Get("votes")
 				if !ok || votes == nil {
 					votes = int64(0)


### PR DESCRIPTION
Hi! I noticed a small bug -- apparently sometimes the demo database has undefined taglines. This should resolve.

## reproduce

```bash
curl http://localhost:8080/search\?q\='a'
```

Server error
```
Running on port 8080, database is at neo4j+s://demo.neo4jlabs.com
2022/03/11 17:03:42 http: panic serving [::1]:51847: interface conversion: interface {} is nil, not string
goroutine 4 [running]:
net/http.(*conn).serve.func1(0x1400011c960)
        /opt/homebrew/Cellar/go/1.17.8/libexec/src/net/http/server.go:1802 +0xdc
panic({0x10517dd20, 0x140002b68a0})
        /opt/homebrew/Cellar/go/1.17.8/libexec/src/runtime/panic.go:1052 +0x2ac
main.searchHandlerFunc.func1.1({0x1051c2458, 0x140002d8080})
        /Users/justin/go/src/github.com/neo4j-examples/movies-golang-bolt/server.go:114 +0x578
github.com/neo4j/neo4j-go-driver/v4/neo4j.(*session).runRetriable(0x1400007d520, 0x1, 0x14000012e10, {0x0, 0x0, 0x0})
        /Users/justin/go/pkg/mod/github.com/neo4j/neo4j-go-driver/v4@v4.4.1/neo4j/session.go:307 +0x374
github.com/neo4j/neo4j-go-driver/v4/neo4j.(*session).ReadTransaction(0x1400007d520, 0x14000012e10, {0x0, 0x0, 0x0})
        /Users/justin/go/pkg/mod/github.com/neo4j/neo4j-go-driver/v4@v4.4.1/neo4j/session.go:355 +0x50
main.searchHandlerFunc.func1({0x1051c1138, 0x140001520e0}, 0x1400015c000)
        /Users/justin/go/src/github.com/neo4j-examples/movies-golang-bolt/server.go:92 +0x23c
net/http.HandlerFunc.ServeHTTP(0x1400007ad80, {0x1051c1138, 0x140001520e0}, 0x1400015c000)
        /opt/homebrew/Cellar/go/1.17.8/libexec/src/net/http/server.go:2047 +0x40
net/http.(*ServeMux).ServeHTTP(0x1400012e200, {0x1051c1138, 0x140001520e0}, 0x1400015c000)
        /opt/homebrew/Cellar/go/1.17.8/libexec/src/net/http/server.go:2425 +0x18c
net/http.serverHandler.ServeHTTP({0x14000152000}, {0x1051c1138, 0x140001520e0}, 0x1400015c000)
        /opt/homebrew/Cellar/go/1.17.8/libexec/src/net/http/server.go:2879 +0x444
net/http.(*conn).serve(0x1400011c960, {0x1051c2340, 0x1400007af60})
        /opt/homebrew/Cellar/go/1.17.8/libexec/src/net/http/server.go:1930 +0xb6c
created by net/http.(*Server).Serve
        /opt/homebrew/Cellar/go/1.17.8/libexec/src/net/http/server.go:3034 +0x4b8
```